### PR TITLE
Adding "between" to the validator.

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ $validator->
     isLen($length)                      // The string must be the exact length
     isLen($min, $max)                   // The string must be between $min and $max length (inclusive)
     isInt()                             // Check for a valid integer
+    isBetween($min, $max)               // The number must be between $min and $max (inclusive)
     isFloat()                           // Check for a valid float/decimal
     isEmail()                           // Check for a valid email
     isUrl()                             // Check for a valid URL

--- a/src/Klein/Validator.php
+++ b/src/Klein/Validator.php
@@ -90,6 +90,9 @@ class Validator
         static::$methods['int'] = function ($str) {
             return (string)$str === ((string)(int)$str);
         };
+        static::$methods['between'] = function ($str, $min, $max) {
+            return (real)$str >= $min && (real)$str <= $max;
+        };
         static::$methods['float'] = function ($str) {
             return (string)$str === ((string)(float)$str);
         };

--- a/tests/Klein/Tests/ValidationsTest.php
+++ b/tests/Klein/Tests/ValidationsTest.php
@@ -217,6 +217,64 @@ class ValidationsTest extends AbstractKleinTest
         );
     }
 
+    public function testBetween()
+    {
+        $this->klein_app->respond(
+            '/[:test_param]',
+            function ($request, $response, $service) {
+                $service->validateParam('test_param')
+                    ->notNull()
+                    ->isBetween(0, 5);
+
+                // We should only get here if we passed our validations
+                echo 'yup!';
+            }
+        );
+
+        $this->assertSame(
+            'fail',
+            $this->dispatchAndReturnOutput(
+                MockRequestFactory::create('/-1')
+            )
+        );
+        $this->assertSame(
+            'yup!',
+            $this->dispatchAndReturnOutput(
+                MockRequestFactory::create('/0')
+            )
+        );
+        $this->assertSame(
+            'yup!',
+            $this->dispatchAndReturnOutput(
+                MockRequestFactory::create('/3')
+            )
+        );
+        $this->assertSame(
+            'yup!',
+            $this->dispatchAndReturnOutput(
+                MockRequestFactory::create('/5')
+            )
+        );
+        $this->assertSame(
+            'yup!',
+            $this->dispatchAndReturnOutput(
+                MockRequestFactory::create('/3.0')
+            )
+        );
+        $this->assertSame(
+            'yup!',
+            $this->dispatchAndReturnOutput(
+                MockRequestFactory::create('/2e0')
+            )
+        );
+        $this->assertSame(
+            'fail',
+            $this->dispatchAndReturnOutput(
+                MockRequestFactory::create('/10,000')
+            )
+        );
+    }
+
     public function testFloat()
     {
         $this->klein_app->respond(


### PR DESCRIPTION
There is code to check the length of a string between two boundaries, but not the magnitude of a number between two boundary values. I've had a go at adding this in; what do people think?