### PR TITLE
Added documentation on how to fix browser console logging components.

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,22 @@ $this->sharedData()->get('myvar')       // Access stored service variables
 echo $this->query(array('page' => 2))   // Modify the current query string
 ```
 
+## Headers Integration With Logging Services
+
+Logging services that send info to the browser console may fail when used with
+Klein. They use HTTP headers for their data and need to send them ahead of when
+Klein does. Klein provides a method to help with this: `$klein->afterDispatch($callable)`.
+
+Here is an example for the `BrowserConsoleHandler` from [Monolog](https://github.com/Seldaek/monolog),
+though a similar pattern should work its `ChromePHPHandler` or `PHPConsoleHandler`.
+
+```php
+$log = new Monolog\Logger('debug');
+$log->pushHandler(new Monolog\Handler\BrowserConsoleHandler());
+
+$klein->afterDispatch(['\Monolog\Handler\BrowserConsoleHandler', 'send']);
+```
+
 ## API
 
 Below is a list of the public methods in the common classes you will most likely use. For a more formal source


### PR DESCRIPTION
I spent a couple of hours trying to figure out why several different [Monolog](https://github.com/Seldaek/monolog) handlers weren't working with my site using Klein. Finally dove into the source code of each to figure out it was a `send_headers()` type of issue.

The fix is to use Klein's `afterDispatch()` method, which is otherwise unmentioned in the
Readme file or the PHPDocs.

I'm not sure of the best place for this in the docs, so chose a section that seemed to fit okay. Feel free to move it around, or leave it out entirely if the method isn't meant for general use.