### PR TITLE
Added ability to pass json encoding options.

### DIFF
--- a/src/Klein/Response.php
+++ b/src/Klein/Response.php
@@ -112,14 +112,15 @@ class Response extends AbstractResponse
      *
      * @param mixed $object         The data to encode as JSON
      * @param string $jsonp_prefix  The name of the JSON-P function prefix
+     * @param int $options          JSON encode options
      * @return Response
      */
-    public function json($object, $jsonp_prefix = null)
+    public function json($object, $jsonp_prefix = null, $options = 0)
     {
         $this->body('');
         $this->noCache();
 
-        $json = json_encode($object);
+        $json = json_encode($object, $options);
 
         if (null !== $jsonp_prefix) {
             // Should ideally be application/json-p once adopted


### PR DESCRIPTION
Added an optional argument to the Response->json method that allows
passing of encoding options like JSON_PRETTY_PRINT.

I hope this is not a duplicate. But i thought it could be handy to be able to pass encoding options to the json response method.

Example:

```php
$response->json($data, null, JSON_PRETTY_PRINT);
```